### PR TITLE
Fix ICA

### DIFF
--- a/scripts/processing/05-run_ica.py
+++ b/scripts/processing/05-run_ica.py
@@ -43,16 +43,10 @@ def run_ica(subject_id, tsss=None):
                            'run_concat-tsss_%d-ica.fif' % tsss)
     else:
         ica_name = op.join(meg_dir, subject, 'run_concat-ica.fif')
-    # Here we only compute ICA for MEG because we only eliminate ECG artifacts,
-    # which are not prevalent in EEG (blink artifacts are, but we will remove
-    # trials with blinks at the epoching stage).
     print('  Fitting ICA')
     ica = ICA(method='fastica', random_state=random_state,
               n_components=n_components)
-    picks = mne.pick_types(raw.info, meg=True, eeg=False, eog=False,
-                           stim=False, exclude='bads')
-    ica.fit(raw, picks=picks, reject=dict(grad=4000e-13, mag=4e-12),
-            decim=11)
+    ica.fit(raw, reject=dict(grad=4000e-13, mag=4e-12), decim=11)
     print('  Fit %d components (explaining at least %0.1f%% of the variance)'
           % (ica.n_components_, 100 * n_components))
     ica.save(ica_name)


### PR DESCRIPTION
ICA ignored the EEG channels, which means EOG artifacts where not cleaned from the EEG sensors, which means autoreject started rejecting a lot of data based on blinks in the EEG.

This should fix it. I'm re-running our [conpy pipeline](https://github.com/wmvanvliet/conpy) now (takes a while...) to see if we get decent results.
